### PR TITLE
Fix CI by replacing npm ci with npm install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Build
-        run: npm ci
+        run: npm install
 
       - name: Lint
         run: npm run lint


### PR DESCRIPTION
The build is failing because `npm ci` should be used only when a lock file exists.